### PR TITLE
Fix Gemini chatbot request format and key handling

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,7 +1,13 @@
 /****************************************************************
 *  KI-Chatbot über Google Gemini API                            *
 ****************************************************************/
-const GEMINI_KEY = "AIzaSyCwSXrm7oP7F5LMCucJnIq1PF96LJTL0I4";
+
+// API-Key nicht im Quellcode speichern.
+// Setze ihn z.B. im HTML vor chat.js:
+// <script>window.GEMINI_API_KEY = "...";</script>
+const GEMINI_KEY = window.GEMINI_API_KEY || "";
+const GEMINI_MODEL = "gemini-2.5-flash";
+
 const systemMsg =
   "Du bist Twin Jegans Bewerbungs-Chatbot. Antworte freundlich, präzise und auf Deutsch. " +
   "Beantworte nur Fragen über Twin Jegan, seine Fähigkeiten, Projekte, Erfahrung und Kontakt. " +
@@ -10,8 +16,7 @@ const systemMsg =
 const botBtn = document.createElement("button");
 botBtn.id = "chatToggle";
 botBtn.type = "button";
-botBtn.className =
-  "fixed bottom-6 right-6 z-50 btn-primary shadow-xl";
+botBtn.className = "fixed bottom-6 right-6 z-50 btn-primary shadow-xl";
 botBtn.textContent = "🤖 KI-Chat";
 
 const panel = document.createElement("section");
@@ -26,8 +31,7 @@ panel.innerHTML = `
   <p class="text-xs text-muted mb-2">Ich beantworte Fragen über Twin Jegan.</p>
   <div id="chatLog" class="flex-1 overflow-y-auto space-y-2 pr-1 mb-3"></div>
   <form id="chatForm" class="flex gap-2">
-    <input id="chatInput" autocomplete="off" placeholder="Deine Frage …"
-      class="input" />
+    <input id="chatInput" autocomplete="off" placeholder="Deine Frage …" class="input" />
     <button class="btn-primary px-3" aria-label="Senden">→</button>
   </form>`;
 
@@ -38,9 +42,7 @@ function togglePanel(show) {
   const shouldOpen = show ?? panel.classList.contains("opacity-0");
   panel.classList.toggle("opacity-0", !shouldOpen);
   panel.classList.toggle("pointer-events-none", !shouldOpen);
-  if (shouldOpen) {
-    document.getElementById("chatInput").focus();
-  }
+  if (shouldOpen) document.getElementById("chatInput").focus();
 }
 
 botBtn.addEventListener("click", () => togglePanel());
@@ -55,6 +57,11 @@ chatForm.addEventListener("submit", async (e) => {
   const question = chatInput.value.trim();
   if (!question) return;
 
+  if (!GEMINI_KEY) {
+    bubble("Kein Gemini API-Key gefunden. Bitte window.GEMINI_API_KEY setzen.", "left");
+    return;
+  }
+
   chatInput.value = "";
   bubble(question, "right");
   const waitBubble = bubble("…", "left", true);
@@ -65,7 +72,7 @@ chatForm.addEventListener("submit", async (e) => {
     bubble(answer, "left");
   } catch (err) {
     waitBubble.remove();
-    bubble("Fehler beim Laden der Antwort. Bitte später nochmals versuchen.", "left");
+    bubble("Fehler bei Gemini. Prüfe API-Key, Modell und API-Freischaltung in Google AI Studio.", "left");
     console.error(err);
   }
 });
@@ -73,9 +80,7 @@ chatForm.addEventListener("submit", async (e) => {
 function bubble(text, side, pending = false) {
   const node = document.createElement("div");
   node.className = `${pending ? "pending" : ""} max-w-[85%] break-words px-3 py-2 rounded-lg ${
-    side === "right"
-      ? "ml-auto bg-[#0A84FF] text-[#0A0A0A]"
-      : "bg-[#27272A] text-[#F2F2F2]"
+    side === "right" ? "ml-auto bg-[#0A84FF] text-[#0A0A0A]" : "bg-[#27272A] text-[#F2F2F2]"
   }`;
   node.textContent = text;
   chatLog.appendChild(node);
@@ -84,29 +89,37 @@ function bubble(text, side, pending = false) {
 }
 
 async function askGemini(userQuestion) {
-  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${GEMINI_KEY}`;
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
   const response = await fetch(endpoint, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "x-goog-api-key": GEMINI_KEY,
+    },
     body: JSON.stringify({
+      systemInstruction: {
+        parts: [{ text: systemMsg }],
+      },
       contents: [
         {
           role: "user",
-          parts: [{ text: `${systemMsg}\n\nFrage: ${userQuestion}` }]
-        }
+          parts: [{ text: userQuestion }],
+        },
       ],
       generationConfig: {
         temperature: 0.5,
-        maxOutputTokens: 250
-      }
-    })
+        maxOutputTokens: 250,
+      },
+    }),
   });
 
+  const data = await response.json();
+
   if (!response.ok) {
-    throw new Error(`Gemini API Fehler: ${response.status}`);
+    const apiError = data?.error?.message || `HTTP ${response.status}`;
+    throw new Error(`Gemini API Fehler: ${apiError}`);
   }
 
-  const data = await response.json();
   const text = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
   return text || "Dazu habe ich gerade keine Antwort.";
 }


### PR DESCRIPTION
### Motivation
- The embedded Gemini request was failing due to an outdated request structure and a hardcoded API key, preventing the on-site chatbot from working. 
- Requests needed to match the current Gemini quickstart shape and authenticate via header to make debugging and deployment safer. 

### Description
- Removed the hardcoded API key and now read the key from `window.GEMINI_API_KEY`, with a runtime notice if it's missing. 
- Introduced `GEMINI_MODEL = "gemini-2.5-flash"` and switched the endpoint to `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`. 
- Send the API key in the `x-goog-api-key` header, add a `systemInstruction` field, and move the user prompt into `contents` to match the quickstart payload. 
- Improved error handling to surface API error messages and updated user-facing error text.

### Testing
- Ran `node --check chat.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d00a08088330a4902b3a5c95b38d)